### PR TITLE
delete repeat "but"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ puts 'Hello world!'
 Then from the terminal
 
 ```bash
-$ opal --compile app.rb > app.js # The Opal runtime is included by default but
+$ opal --compile app.rb > app.js # The Opal runtime is included by default
                                  # but can be skipped with the --no-opal flag
 ```
 


### PR DESCRIPTION
There were double 'but' in

``` terminal
$ opal --compile app.rb > app.js # The Opal runtime is included by default but
                                                   # but can be skipped with the --no-opal flag
```

. Deleted one.
